### PR TITLE
adding EventCallback (minor cleanup Toolkit)

### DIFF
--- a/Toolkit/Arrays/DynArray/_Tests/main.cpp
+++ b/Toolkit/Arrays/DynArray/_Tests/main.cpp
@@ -12,7 +12,7 @@
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
 
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 extern int TestPart1(int testNumber);
 extern int StressTest(int testNumber);

--- a/Toolkit/Arrays/DynArray/_Tests/test1.cpp
+++ b/Toolkit/Arrays/DynArray/_Tests/test1.cpp
@@ -11,7 +11,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 int TestPart1(int testNumber)
 {
@@ -44,7 +44,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	/***************************************/
 
@@ -74,7 +73,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	/*******************  ************************/
 
@@ -104,7 +102,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
 
@@ -138,7 +135,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
     return (testNumber);

--- a/Toolkit/Arrays/DynArray/_Tests/test2.cpp
+++ b/Toolkit/Arrays/DynArray/_Tests/test2.cpp
@@ -11,7 +11,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 class EmplaceTwo
 {
@@ -82,8 +82,7 @@ int StressTest(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
-	}
+        	}
 
 /******************************************************************** */
 
@@ -129,7 +128,6 @@ int StressTest(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
 /******************************************************************** */
@@ -194,7 +192,6 @@ int StressTest(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
 /******************************************************************** */
@@ -228,7 +225,6 @@ int StressTest(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
     return (testNumber);

--- a/Toolkit/Arrays/DynArray/_Tests/test3.cpp
+++ b/Toolkit/Arrays/DynArray/_Tests/test3.cpp
@@ -11,7 +11,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 int TestPart3(int testNumber)
 {
@@ -68,7 +68,6 @@ int TestPart3(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
     return (testNumber);
 }

--- a/Toolkit/Arrays/HeapArray/_Tests/main.cpp
+++ b/Toolkit/Arrays/HeapArray/_Tests/main.cpp
@@ -12,7 +12,7 @@
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
 
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 extern int TestPart1(int testNumber);
 extern int StressTest(int testNumber);

--- a/Toolkit/Arrays/HeapArray/_Tests/test1.cpp
+++ b/Toolkit/Arrays/HeapArray/_Tests/test1.cpp
@@ -10,7 +10,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 int TestPart1(int testNumber)
@@ -27,16 +27,16 @@ int TestPart1(int testNumber)
 			array.push_back(i);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<int>::iterator it = array.begin();
 		std::vector<int>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -59,16 +59,16 @@ int TestPart1(int testNumber)
 			array.push_back(i);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<ToolkitDummy>::iterator it = array.begin();
 		std::vector<ToolkitDummy>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -90,16 +90,16 @@ int TestPart1(int testNumber)
 			array.emplace_back(i);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<ToolkitDummy>::iterator it = array.begin();
 		std::vector<ToolkitDummy>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -126,16 +126,16 @@ int TestPart1(int testNumber)
 			array.emplace_back(array[0]);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<ToolkitDummy>::iterator it = array.begin();
 		std::vector<ToolkitDummy>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 		std::cout << "	PASSED" << std::endl;
 	}

--- a/Toolkit/Arrays/HeapArray/_Tests/test2.cpp
+++ b/Toolkit/Arrays/HeapArray/_Tests/test2.cpp
@@ -12,12 +12,12 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 class EmplaceTwo
 {
     public:
-        EmplaceTwo(const std::string& name, const int number) : m_name(name), m_number(number), m_present(m_name + " " + to_string(m_number)) {};
+        EmplaceTwo(const std::string& name, const int number) : m_name(name), m_number(number), m_present(m_name + " " + TestHelpers::to_string(m_number)) {};
 		~EmplaceTwo() {};
 		
         bool operator==(const EmplaceTwo& other)
@@ -55,16 +55,16 @@ int StressTest(int testNumber)
 			array.emplace_back(i);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<int>::iterator it = array.begin();
 		std::vector<int>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         HeapArray<int> assign(100);
@@ -80,13 +80,13 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::runtime_error("copy assignment value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::runtime_error("copy assignment value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::runtime_error("copy assignment, size mismatch, got: " + to_string(assign.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("copy assignment, size mismatch, got: " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -106,20 +106,20 @@ int StressTest(int testNumber)
 
 		for (int i = 0; i < 100; ++i)
 		{
-			std.push_back("big string the will require allocation on the heap " + to_string(i));
-			array.emplace_back("big string the will require allocation on the heap " + to_string(i));
+			std.push_back("big string the will require allocation on the heap " + TestHelpers::to_string(i));
+			array.emplace_back("big string the will require allocation on the heap " + TestHelpers::to_string(i));
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<std::string>::iterator it = array.begin();
 		std::vector<std::string>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         HeapArray<std::string> assign(100);
@@ -134,13 +134,13 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::runtime_error("copy assignment, value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::runtime_error("copy assignment, value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::runtime_error("copy assignment, size mismatch, got: " + to_string(assign.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("copy assignment, size mismatch, got: " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -164,16 +164,16 @@ int StressTest(int testNumber)
 			array.emplace_back(i);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<int>::iterator it = array.begin();
 		std::vector<int>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         HeapArray<int> assign(array);
@@ -184,13 +184,13 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::runtime_error("copy, constructor value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::runtime_error("copy, constructor value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::logic_error("copy constructor, size mismatch got: " + to_string(assign.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("copy constructor, size mismatch got: " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -214,16 +214,16 @@ int StressTest(int testNumber)
 			array.emplace_back(i);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<int>::iterator it = array.begin();
 		std::vector<int>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         HeapArray<int> assign(100);
@@ -239,23 +239,23 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::logic_error("::move failed, value mismatch got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("::move failed, value mismatch got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::logic_error("::move failed, got: " + to_string(assign.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("::move failed, got: " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (array.size() != 0)
             throw std::logic_error("::move failed, source array not empty" + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));    
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));    
 
         assign.clear();
 
         if (assign.size() != 0)
             throw std::logic_error("::clear failed, array not empty" + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -302,8 +302,8 @@ int StressTest(int testNumber)
 		}
 
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<EmplaceTwo>::iterator it = array.begin();
 		std::vector<EmplaceTwo>::iterator iter = std.begin();
@@ -311,7 +311,7 @@ int StressTest(int testNumber)
 		{
 			if (*it != *iter)
 				throw std::logic_error("value mismatch got: " + it->present() + " expected: " + iter->present() + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		std::cout << "	PASSED" << std::endl;

--- a/Toolkit/Arrays/HeapArray/_Tests/test3.cpp
+++ b/Toolkit/Arrays/HeapArray/_Tests/test3.cpp
@@ -12,7 +12,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 int TestPart3(int testNumber)
@@ -43,8 +43,8 @@ int TestPart3(int testNumber)
 			array.push_back(new ToolkitBase(i));
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapArray<ToolkitBase*>::iterator it = array.begin();
 		std::vector<ToolkitBase*>::iterator iter = std.begin();
@@ -52,7 +52,7 @@ int TestPart3(int testNumber)
 		{
 			if (**it != **iter)
 				throw std::runtime_error("value mismatch " + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		it = array.begin();

--- a/Toolkit/Arrays/HeapCircularQueue/_Tests/main.cpp
+++ b/Toolkit/Arrays/HeapCircularQueue/_Tests/main.cpp
@@ -13,7 +13,7 @@
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
 
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 extern int TestPart1(int testNumber);
 extern int StressTest(int testNumber);

--- a/Toolkit/Arrays/HeapCircularQueue/_Tests/test1.cpp
+++ b/Toolkit/Arrays/HeapCircularQueue/_Tests/test1.cpp
@@ -13,7 +13,7 @@
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
 
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 int TestPart1(int testNumber)
 {
@@ -39,12 +39,12 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
                
@@ -53,34 +53,34 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
 
         if (queue[0] != frontNumber)
-            throw std::logic_error("index 0 is: " + to_string(queue[0]) + " but should be: " + to_string(frontNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("index 0 is: " + TestHelpers::to_string(queue[0]) + " but should be: " + TestHelpers::to_string(frontNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		
         if (queue[1] != backNumber)
-			throw std::logic_error("index 1 is: " + to_string(queue[1]) + " but should be: " + to_string(frontNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("index 1 is: " + TestHelpers::to_string(queue[1]) + " but should be: " + TestHelpers::to_string(frontNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         if (queue.back() != backNumber)
-            throw std::logic_error("back is " + to_string(queue.back()) + " but should be: " + to_string(backNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("back is " + TestHelpers::to_string(queue.back()) + " but should be: " + TestHelpers::to_string(backNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         if (queue.front() != frontNumber)
-            throw std::logic_error("back is " + to_string(queue.front()) + " but should be: " + to_string(backNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("back is " + TestHelpers::to_string(queue.front()) + " but should be: " + TestHelpers::to_string(backNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 
@@ -89,8 +89,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
        
@@ -99,14 +99,14 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
  
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }  
 
         /************* */
@@ -116,13 +116,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }  
 
         /************* */
@@ -132,13 +132,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }   
         
 
@@ -149,8 +149,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
     /************* */
 
@@ -159,8 +159,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
         /************* */
@@ -169,13 +169,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += resultInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         } 
 
 		std::cout << "	PASSED" << std::endl;
@@ -211,12 +211,12 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
                
@@ -225,38 +225,38 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
 
         if (queue[0] != frontNumber)
-            throw std::logic_error("index 0 is: " + to_string(queue[0]) + " but should be: " + to_string(frontNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("index 0 is: " + TestHelpers::to_string(queue[0]) + " but should be: " + TestHelpers::to_string(frontNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		
         
         if (queue[1] != backNumber)
-			throw std::logic_error("index 1 is: " + to_string(queue[1]) + " but should be: " + to_string(frontNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("index 1 is: " + TestHelpers::to_string(queue[1]) + " but should be: " + TestHelpers::to_string(frontNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         
         if (queue.back() != backNumber)
-            throw std::logic_error("back is " + to_string(queue.back()) + " but should be: " + to_string(backNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("back is " + TestHelpers::to_string(queue.back()) + " but should be: " + TestHelpers::to_string(backNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         
         if (queue.front() != frontNumber)
-            throw std::logic_error("back is " + to_string(queue.front()) + " but should be: " + to_string(backNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("back is " + TestHelpers::to_string(queue.front()) + " but should be: " + TestHelpers::to_string(backNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
         resultInsertion = queue.push_front(10);
@@ -264,8 +264,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
        
@@ -274,14 +274,14 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
  
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }  
 
         /************* */
@@ -291,13 +291,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }  
 
         /************* */
@@ -307,13 +307,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }   
         
 
@@ -324,8 +324,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
     /************* */
 
@@ -334,8 +334,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
         /************* */
@@ -344,13 +344,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += resultInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         } 
 
 		std::cout << "	PASSED" << std::endl;
@@ -371,7 +371,7 @@ int TestPart1(int testNumber)
 
         if (it != itEnd)
             throw std::logic_error("iterators, empty queue, begin and end should be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -394,19 +394,19 @@ int TestPart1(int testNumber)
 
         if (it == itEnd)
             throw std::logic_error("iterators, push_back, non-full queue, begin and end should not be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t i = 0;
         for ( ; it != itEnd; ++it, ++i)
         {
             if (*it != queue[i])
-                throw std::logic_error("iterators, push_back, non-full queue, value mismatch, got " + to_string(*it) + " expected: " + to_string(queue[i]) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("iterators, push_back, non-full queue, value mismatch, got " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(queue[i]) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (i != queue.size())
-            throw std::logic_error("iterators, push_back, non-full queue, size mismatch, got " + to_string(i) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("iterators, push_back, non-full queue, size mismatch, got " + TestHelpers::to_string(i) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -429,19 +429,19 @@ int TestPart1(int testNumber)
 
         if (it == itEnd)
             throw std::logic_error("iterators, push_back, non-full queue, begin and end should not be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t i = 0;
         for ( ; it != itEnd; ++it, ++i)
         {
             if (*it != queue[i])
-                throw std::logic_error("iterators, push_back, non-full queue, value mismatch, got " + to_string(*it) + " expected: " + to_string(queue[i]) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("iterators, push_back, non-full queue, value mismatch, got " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(queue[i]) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (i != queue.size())
-            throw std::logic_error("iterators, push_back, non-full queue, size mismatch, got " + to_string(i) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("iterators, push_back, non-full queue, size mismatch, got " + TestHelpers::to_string(i) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -464,19 +464,19 @@ int TestPart1(int testNumber)
 
         if (it == itEnd)
             throw std::logic_error("iterators, push_front, non-full queue, begin and end should not be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t i = 0;
         for ( ; it != itEnd; ++it, ++i)
         {
             if (*it != queue[i])
-                throw std::logic_error("iterators, push_front, non-full queue, value mismatch, got " + to_string(*it) + " expected: " + to_string(queue[i]) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("iterators, push_front, non-full queue, value mismatch, got " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(queue[i]) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (i != queue.size())
-            throw std::logic_error("iterators, push_front, non-full queue, size mismatch, got " + to_string(i) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("iterators, push_front, non-full queue, size mismatch, got " + TestHelpers::to_string(i) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -499,19 +499,19 @@ int TestPart1(int testNumber)
 
         if (it == itEnd)
             throw std::logic_error("iterators, push_front, non-full queue, begin and end should not be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t i = 0;
         for ( ; it != itEnd; ++it, ++i)
         {
             if (*it != queue[i])
-                throw std::logic_error("iterators, push_front, non-full queue, value mismatch, got " + to_string(*it) + " expected: " + to_string(queue[i]) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("iterators, push_front, non-full queue, value mismatch, got " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(queue[i]) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (i != queue.size())
-            throw std::logic_error("iterators, push_front, non-full queue, size mismatch, got " + to_string(i) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("iterators, push_front, non-full queue, size mismatch, got " + TestHelpers::to_string(i) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -532,8 +532,8 @@ int TestPart1(int testNumber)
         HeapCircularQueue<int> copy(queue);
 
         if (queue.size() != copy.size())
-            throw std::logic_error("copy constructor, full copy-from, size mismatch, got " + to_string(copy.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("copy constructor, full copy-from, size mismatch, got " + TestHelpers::to_string(copy.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = copy.begin();
@@ -541,8 +541,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != copy.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("copy constructor, full copy-from, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy constructor, full copy-from, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -564,8 +564,8 @@ int TestPart1(int testNumber)
         HeapCircularQueue<int> copy(queue);
 
         if (queue.size() != copy.size())
-            throw std::logic_error("copy constructor, not-full copy-from, size mismatch, got " + to_string(copy.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("copy constructor, not-full copy-from, size mismatch, got " + TestHelpers::to_string(copy.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = copy.begin();
@@ -573,8 +573,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != copy.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("copy constructor, not-full copy-from value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy constructor, not-full copy-from value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -593,8 +593,8 @@ int TestPart1(int testNumber)
         HeapCircularQueue<int> copy(queue);
 
         if (queue.size() != copy.size())
-            throw std::logic_error("copy constructor, empty copy-from, size mismatch, got " + to_string(copy.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("copy constructor, empty copy-from, size mismatch, got " + TestHelpers::to_string(copy.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = copy.begin();
@@ -602,8 +602,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != copy.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("copy constructor, empty copy-from value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy constructor, empty copy-from value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -627,8 +627,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, full copy-from, empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, full copy-from, empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -636,8 +636,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, full copy-from, empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, full copy-from, empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -661,8 +661,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, non-full copy-from, empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, non-full copy-from, empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -670,8 +670,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, non-full copy-from, empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, non-full copy-from, empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -691,8 +691,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, empty copy-from, empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, empty copy-from, empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -700,8 +700,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, empty copy-from, empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, empty copy-from, empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -726,8 +726,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, full copy-from, non-empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, full copy-from, non-empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -735,8 +735,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, full copy-from, non-empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, full copy-from, non-empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -761,8 +761,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, non-full copy-from, non-empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, non-full copy-from, non-empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -770,8 +770,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, non-full copy-from, non-empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, non-full copy-from, non-empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -793,8 +793,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, empty copy-from, non-empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, empty copy-from, non-empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -802,8 +802,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, empty copy-from, non-empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, empty copy-from, non-empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -830,8 +830,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, full copy-from, full copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, full copy-from, full copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -839,8 +839,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, full copy-from, full copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, full copy-from, full copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -866,8 +866,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, non-full copy-from, full copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, non-full copy-from, full copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -875,8 +875,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, non-full copy-from, full copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, non-full copy-from, full copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -900,8 +900,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, empty copy-from, full copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, empty copy-from, full copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         HeapCircularQueue<int>::iterator itOriginal = queue.begin();
         HeapCircularQueue<int>::iterator itCopy = assign.begin();
@@ -909,8 +909,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, empty copy-from, full copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, empty copy-from, full copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;

--- a/Toolkit/Arrays/HeapCircularQueue/_Tests/test2.cpp
+++ b/Toolkit/Arrays/HeapCircularQueue/_Tests/test2.cpp
@@ -12,13 +12,13 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 class EmplaceTwo
 {
     public:
-        EmplaceTwo(const std::string& name, const int number) : m_name(name), m_number(number), m_present (std::string(m_name) + " " + to_string(m_number)) {};
+        EmplaceTwo(const std::string& name, const int number) : m_name(name), m_number(number), m_present (std::string(m_name) + " " + TestHelpers::to_string(m_number)) {};
 		~EmplaceTwo() {};
 		
         bool operator==(const EmplaceTwo& other)
@@ -62,8 +62,8 @@ int StressTest(int testNumber)
 			queue.emplace_back(i);
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapCircularQueue<int>::iterator it = queue.begin();
 		std::vector<int>::iterator iter = std.begin();
@@ -71,8 +71,8 @@ int StressTest(int testNumber)
 		for ( ; it != queue.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::logic_error("value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::logic_error("value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         HeapCircularQueue<int> assign(100);
@@ -82,12 +82,12 @@ int StressTest(int testNumber)
         assign = queue;
 
 		if (queue.size() != assign.size())
-			throw std::logic_error("size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		if (std.size() != assign.size())
-			throw std::logic_error("size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(std.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(std.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         it = assign.begin();
         iter = std.begin();
@@ -95,13 +95,13 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::logic_error("copy assignment, value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy assignment, value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::logic_error("copy assignment, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(std.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("copy assignment, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(std.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -126,16 +126,16 @@ int StressTest(int testNumber)
 			queue.push_back(i);
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapCircularQueue<int>::iterator it = queue.begin();
 		std::vector<int>::iterator iter = std.begin();
 		for ( ; it != queue.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::logic_error("value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::logic_error("value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         HeapCircularQueue<int> assign(100);
@@ -145,8 +145,8 @@ int StressTest(int testNumber)
         assign = queue;
 
 		if (std.size() != assign.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(assign.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(assign.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         it = assign.begin();
         iter = std.begin();
@@ -154,13 +154,13 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::logic_error("copy assignment, value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy assignment, value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::logic_error("copy assignment, size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("copy assignment, size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -181,12 +181,12 @@ int StressTest(int testNumber)
 
 		for (int i = 0; i < 100; ++i)
 		{
-			std.push_back("big string the will require allocation on the heap " + to_string(i));
-			queue.emplace_back("big string the will require allocation on the heap " + to_string(i));
+			std.push_back("big string the will require allocation on the heap " + TestHelpers::to_string(i));
+			queue.emplace_back("big string the will require allocation on the heap " + TestHelpers::to_string(i));
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapCircularQueue<std::string>::iterator it = queue.begin();
 		std::vector<std::string>::iterator iter = std.begin();
@@ -194,7 +194,7 @@ int StressTest(int testNumber)
 		{
 			if (*it != *iter)
 				throw std::logic_error("value mismatch, got '" + *it + "'\n expected: '" + *iter + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         HeapCircularQueue<std::string> assign(100);
@@ -210,12 +210,12 @@ int StressTest(int testNumber)
         {
             if (*it != *iter)
                 throw std::logic_error("copy assignment, value mismatch, \ngot '" + *it + "'\n expected: '" + *iter + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::logic_error("copy assignment, size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("copy assignment, size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -247,8 +247,8 @@ int StressTest(int testNumber)
 		for ( ; it != queue.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::logic_error("value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::logic_error("value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         HeapCircularQueue<int> assign(queue);
@@ -259,8 +259,8 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::logic_error("copy constructor, value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy constructor, value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
@@ -314,8 +314,8 @@ int StressTest(int testNumber)
 		}
 
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapCircularQueue<EmplaceTwo>::iterator it = queue.begin();
 		std::vector<EmplaceTwo>::iterator iter = std.begin();
@@ -323,7 +323,7 @@ int StressTest(int testNumber)
 		{
 			if (*it != *iter)
 				throw std::logic_error("value mismatch, \ngot '" + it->present() + "'\n expected: '" + iter->present() + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		std::cout << "	PASSED" << std::endl;

--- a/Toolkit/Arrays/HeapCircularQueue/_Tests/test3.cpp
+++ b/Toolkit/Arrays/HeapCircularQueue/_Tests/test3.cpp
@@ -12,7 +12,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 int TestPart3(int testNumber)
@@ -43,16 +43,16 @@ int TestPart3(int testNumber)
 			queue.push_front(new ToolkitBase(i));
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size())
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size())
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapCircularQueue<ToolkitBase*>::iterator it = queue.begin();
 		std::list<ToolkitBase*>::iterator iter = std.begin();
 		for ( ; it != queue.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (**it != **iter)
-				throw std::logic_error("value mismatch, got " + to_string((*it)->getValue()) + " expected: " + to_string((*iter)->getValue())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::logic_error("value mismatch, got " + TestHelpers::to_string((*it)->getValue()) + " expected: " + TestHelpers::to_string((*iter)->getValue())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		it = queue.begin();

--- a/Toolkit/Arrays/HeapCircularQueue/_Tests/test4.cpp
+++ b/Toolkit/Arrays/HeapCircularQueue/_Tests/test4.cpp
@@ -11,7 +11,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 int TestPart4(int testNumber)
@@ -31,8 +31,8 @@ int TestPart4(int testNumber)
 			queue.push_front(i);
 		}
 		if (list.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(list.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(list.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapCircularQueue<int>::iterator it = queue.begin();
 		std::list<int>::iterator iter = list.begin();
@@ -62,8 +62,8 @@ int TestPart4(int testNumber)
 			queue.push_back(i);
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapCircularQueue<ToolkitDummy>::iterator it = queue.begin();
 		std::list<ToolkitDummy>::iterator iter = std.begin();
@@ -93,8 +93,8 @@ int TestPart4(int testNumber)
 			queue.emplace_back(i);
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		HeapCircularQueue<ToolkitDummy>::iterator it = queue.begin();
 		std::list<ToolkitDummy>::iterator iter = std.begin();
@@ -127,8 +127,8 @@ int TestPart4(int testNumber)
 			queue.emplace_back(i);
 		}
 		if (list.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(list.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(list.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		HeapCircularQueue<ToolkitDummy>::iterator it = queue.begin();

--- a/Toolkit/Arrays/StackArray/_Tests/test1.cpp
+++ b/Toolkit/Arrays/StackArray/_Tests/test1.cpp
@@ -11,7 +11,7 @@
 #include "../../../_Tests/ToolkitDummy.hpp"
 #include "../../../_Tests/ToolkitBase.hpp"
 #include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 int TestPart1(int testNumber)
@@ -24,8 +24,8 @@ int TestPart1(int testNumber)
 		StackArray<int, arraySize> array;
 
 		if (array.capacity() != arraySize)
-			throw std::runtime_error("size mismatch, got: " + to_string(array.capacity()) + " expected: " + to_string(arraySize) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.capacity()) + " expected: " + TestHelpers::to_string(arraySize) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		for (int i = 0; i < 100; ++i)
@@ -33,13 +33,13 @@ int TestPart1(int testNumber)
 			array.emplace_back(i);
 		}
 		if (array.size() != arraySize)
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(arraySize) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(arraySize) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		for (int i = 0; i < 100; ++i)
 		{
 			if (array[i] != i)
-				throw std::runtime_error("value mismatch, got: " + to_string(array[i]) + " expected: " + to_string(i) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(array[i]) + " expected: " + TestHelpers::to_string(i) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -59,14 +59,14 @@ int TestPart1(int testNumber)
 		StackArray<int, arraySize> array(copyInit);
 		if (array.size() != arraySize)
 
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(arraySize) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(arraySize) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		for (size_t i = 0; i < array.size(); ++i)
 		{
 			if (array[i] != copyInit)
-				throw std::runtime_error("value mismatch, got: " + to_string(array[i]) + " expected: " + to_string(copyInit) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(array[i]) + " expected: " + TestHelpers::to_string(copyInit) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -92,14 +92,14 @@ int TestPart1(int testNumber)
 		}
 
 		if (array.size() != arraySize)
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(arraySize) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(arraySize) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 			
 		for (size_t i = 0; i < array.size(); ++i)
 		{
 			if (array[i] != i)
-				throw std::runtime_error("value mismatch, got: " + to_string(array[i]) + " expected: " + to_string(i) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(array[i]) + " expected: " + TestHelpers::to_string(i) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -121,12 +121,12 @@ int TestPart1(int testNumber)
 		}
 		array.pop_back();
 		if (array.size() != 99)
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(99) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(99) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		if (array.back() != 98)
-			throw std::runtime_error("value mismatch, got: " + to_string(array.back()) + " expected: " + to_string(98) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(array.back()) + " expected: " + TestHelpers::to_string(98) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -147,11 +147,11 @@ int TestPart1(int testNumber)
 
 		// Check front and back
 		if (array.front() != 0)
-			throw std::runtime_error("incorrect front element, got: " + to_string(array.front()) + " expected: " + to_string(0) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("incorrect front element, got: " + TestHelpers::to_string(array.front()) + " expected: " + TestHelpers::to_string(0) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		if (array.back() != 99)
-			throw std::runtime_error("incorrect back element, got: " + to_string(array.back()) + " expected: " + to_string(99) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("incorrect back element, got: " + TestHelpers::to_string(array.back()) + " expected: " + TestHelpers::to_string(99) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -171,14 +171,14 @@ int TestPart1(int testNumber)
 		array.emplace_back(3);
 
 		if (array.size() != 3)
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(3) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(3) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		array.emplace_back(4);
 		array.emplace_back(5);
 		if (array.size() != 5)
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(5) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(5) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -201,18 +201,18 @@ int TestPart1(int testNumber)
 		// Test iterator
 		StackArray<int, 5>::iterator it = array.begin();
 		if (*it != 1)
-			throw std::runtime_error("incorrect value at iterator begin, got: " + to_string(*it) + " expected: " + to_string(1) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("incorrect value at iterator begin, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(1) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		it++;
 		if (*it != 2)
-		throw std::runtime_error("incorrect value at second iterator, got: " + to_string(*it) + " expected: " + to_string(2) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+		throw std::runtime_error("incorrect value at second iterator, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(2) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		it++;
 		if (*it != 3)
-			throw std::runtime_error("incorrect value at third iterator, got: " + to_string(*it) + " expected: " + to_string(3) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("incorrect value at third iterator, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(3) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		it++;
 
@@ -237,7 +237,7 @@ int TestPart1(int testNumber)
 		array.emplace_back("StackArray");
 
 		if (array[0] != "Hello" || array[1] != "World" || array[2] != "StackArray")
-			throw std::logic_error("value mismatch\n" + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("value mismatch\n" + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}

--- a/Toolkit/Arrays/StackArray/_Tests/test2.cpp
+++ b/Toolkit/Arrays/StackArray/_Tests/test2.cpp
@@ -12,7 +12,7 @@
 #include "../../../_Tests/ToolkitDummy.hpp"
 #include "../../../_Tests/ToolkitBase.hpp"
 #include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 int StressTest(int testNumber)
 {
@@ -31,8 +31,8 @@ int StressTest(int testNumber)
 			array.emplace_back(i);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackArray<int, 100>::iterator it = array.begin();
 		std::vector<int>::iterator iter = std.begin();
@@ -40,8 +40,8 @@ int StressTest(int testNumber)
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         StackArray<int, 100> assign;
@@ -57,13 +57,13 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
 			if (*it != *iter)
-				throw std::runtime_error("copy assignment value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("copy assignment value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::runtime_error("copy assignment size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(assign.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("copy assignment size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(assign.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -90,16 +90,16 @@ int StressTest(int testNumber)
 			array.emplace_back(i);
 		}
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackArray<int, 100>::iterator it = array.begin();
 		std::vector<int>::iterator iter = std.begin();
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         StackArray<int, 100> copy(array);
@@ -110,13 +110,13 @@ int StressTest(int testNumber)
         for ( ; it != copy.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::runtime_error("copy constructor value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::runtime_error("copy constructor value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != copy.size())
-			throw std::runtime_error("copy constructor size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(copy.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("copy constructor size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(copy.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -144,8 +144,8 @@ int StressTest(int testNumber)
 		}
 
 		if (std.size() != array.size())
-			throw std::runtime_error("size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(std.size()) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		StackArray<int, arraySize>::iterator it = array.begin();
@@ -153,8 +153,8 @@ int StressTest(int testNumber)
 		for ( ; it != array.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::runtime_error("value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         StackArray<int, arraySize> copy(array);
@@ -165,13 +165,13 @@ int StressTest(int testNumber)
         for ( ; it != copy.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::runtime_error("copy constructor value mismatch, got: " + to_string(*it) + " expected: " + to_string(*iter) + '\n'
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::runtime_error("copy constructor value mismatch, got: " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(*iter) + '\n'
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != copy.size())
-			throw std::runtime_error("copy constructor size mismatch, got: " + to_string(array.size()) + " expected: " + to_string(copy.size()) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("copy constructor size mismatch, got: " + TestHelpers::to_string(array.size()) + " expected: " + TestHelpers::to_string(copy.size()) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;

--- a/Toolkit/Arrays/StackCircularQueue/_Tests/main.cpp
+++ b/Toolkit/Arrays/StackCircularQueue/_Tests/main.cpp
@@ -14,7 +14,7 @@
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
 
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 extern int TestPart1(int testNumber);
 extern int StressTest(int testNumber);

--- a/Toolkit/Arrays/StackCircularQueue/_Tests/test1.cpp
+++ b/Toolkit/Arrays/StackCircularQueue/_Tests/test1.cpp
@@ -14,7 +14,7 @@
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
 
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 int TestPart1(int testNumber)
 {
@@ -40,12 +40,12 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
                
@@ -54,34 +54,34 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
 
         if (queue[0] != frontNumber)
-            throw std::logic_error("index 0 is: " + to_string(queue[0]) + " but should be: " + to_string(frontNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("index 0 is: " + TestHelpers::to_string(queue[0]) + " but should be: " + TestHelpers::to_string(frontNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		
         if (queue[1] != backNumber)
-			throw std::logic_error("index 1 is: " + to_string(queue[1]) + " but should be: " + to_string(frontNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("index 1 is: " + TestHelpers::to_string(queue[1]) + " but should be: " + TestHelpers::to_string(frontNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         if (queue.back() != backNumber)
-            throw std::logic_error("back is " + to_string(queue.back()) + " but should be: " + to_string(backNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("back is " + TestHelpers::to_string(queue.back()) + " but should be: " + TestHelpers::to_string(backNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         if (queue.front() != frontNumber)
-            throw std::logic_error("back is " + to_string(queue.front()) + " but should be: " + to_string(backNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("back is " + TestHelpers::to_string(queue.front()) + " but should be: " + TestHelpers::to_string(backNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 
@@ -90,8 +90,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
        
@@ -100,14 +100,14 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
  
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }  
 
         /************* */
@@ -117,13 +117,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }  
 
         /************* */
@@ -133,13 +133,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }   
         
 
@@ -150,8 +150,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
     /************* */
 
@@ -160,8 +160,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
         /************* */
@@ -170,13 +170,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += resultInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         } 
 
 		std::cout << "	PASSED" << std::endl;
@@ -212,12 +212,12 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
                
@@ -226,38 +226,38 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
 
         if (queue[0] != frontNumber)
-            throw std::logic_error("index 0 is: " + to_string(queue[0]) + " but should be: " + to_string(frontNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("index 0 is: " + TestHelpers::to_string(queue[0]) + " but should be: " + TestHelpers::to_string(frontNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		
         
         if (queue[1] != backNumber)
-			throw std::logic_error("index 1 is: " + to_string(queue[1]) + " but should be: " + to_string(frontNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("index 1 is: " + TestHelpers::to_string(queue[1]) + " but should be: " + TestHelpers::to_string(frontNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         
         if (queue.size() != expectedElemCount)
-            throw std::logic_error("size is " + to_string(queue.size()) + " but should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size is " + TestHelpers::to_string(queue.size()) + " but should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         
         if (queue.back() != backNumber)
-            throw std::logic_error("back is " + to_string(queue.back()) + " but should be: " + to_string(backNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("back is " + TestHelpers::to_string(queue.back()) + " but should be: " + TestHelpers::to_string(backNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         
         
         if (queue.front() != frontNumber)
-            throw std::logic_error("back is " + to_string(queue.front()) + " but should be: " + to_string(backNumber) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("back is " + TestHelpers::to_string(queue.front()) + " but should be: " + TestHelpers::to_string(backNumber) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
         resultInsertion = queue.push_front(10);
@@ -265,8 +265,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         /************* */
        
@@ -275,14 +275,14 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
  
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }  
 
         /************* */
@@ -292,13 +292,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }  
 
         /************* */
@@ -308,13 +308,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }   
         
 
@@ -325,8 +325,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
     /************* */
 
@@ -335,8 +335,8 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount > 0);
         expectedElemCount -= expectedInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
         /************* */
@@ -345,13 +345,13 @@ int TestPart1(int testNumber)
         expectedInsertion = (expectedElemCount < queueSize);
         expectedElemCount += resultInsertion;
         if (resultInsertion != expectedInsertion)
-            throw std::logic_error("result was " + to_string(resultInsertion) + " but expected: " + to_string(expectedInsertion) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("result was " + TestHelpers::to_string(resultInsertion) + " but expected: " + TestHelpers::to_string(expectedInsertion) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (queue.size() != expectedElemCount)
         {
-            throw std::logic_error("size doesn't match, size is: " + to_string(queue.size()) + ", should be: " + to_string(expectedElemCount) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("size doesn't match, size is: " + TestHelpers::to_string(queue.size()) + ", should be: " + TestHelpers::to_string(expectedElemCount) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         } 
 
 		std::cout << "	PASSED" << std::endl;
@@ -373,7 +373,7 @@ int TestPart1(int testNumber)
 
         if (it != itEnd)
             throw std::logic_error("iterators, empty queue, begin and end should be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -397,19 +397,19 @@ int TestPart1(int testNumber)
 
         if (it == itEnd)
             throw std::logic_error("iterators, push_back, non-full queue, begin and end should not be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t i = 0;
         for ( ; it != itEnd; ++it, ++i)
         {
             if (*it != queue[i])
-                throw std::logic_error("iterators, push_back, non-full queue, value mismatch, got " + to_string(*it) + " expected: " + to_string(queue[i]) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("iterators, push_back, non-full queue, value mismatch, got " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(queue[i]) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (i != queue.size())
-            throw std::logic_error("iterators, push_back, non-full queue, size mismatch, got " + to_string(i) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("iterators, push_back, non-full queue, size mismatch, got " + TestHelpers::to_string(i) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -433,19 +433,19 @@ int TestPart1(int testNumber)
 
         if (it == itEnd)
             throw std::logic_error("iterators, push_back, non-full queue, begin and end should not be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t i = 0;
         for ( ; it != itEnd; ++it, ++i)
         {
             if (*it != queue[i])
-                throw std::logic_error("iterators, push_back, non-full queue, value mismatch, got " + to_string(*it) + " expected: " + to_string(queue[i]) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("iterators, push_back, non-full queue, value mismatch, got " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(queue[i]) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (i != queue.size())
-            throw std::logic_error("iterators, push_back, non-full queue, size mismatch, got " + to_string(i) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("iterators, push_back, non-full queue, size mismatch, got " + TestHelpers::to_string(i) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -468,19 +468,19 @@ int TestPart1(int testNumber)
         StackCircularQueue<int, queueSize>::iterator itEnd = queue.end();
         if (it == itEnd)
             throw std::logic_error("iterators, push_front, non-full queue, begin and end should not be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t i = 0;
         for ( ; it != itEnd; ++it, ++i)
         {
             if (*it != queue[i])
-                throw std::logic_error("iterators, push_front, non-full queue, value mismatch, got " + to_string(*it) + " expected: " + to_string(queue[i]) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("iterators, push_front, non-full queue, value mismatch, got " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(queue[i]) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (i != queue.size())
-            throw std::logic_error("iterators, push_front, non-full queue, size mismatch, got " + to_string(i) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("iterators, push_front, non-full queue, size mismatch, got " + TestHelpers::to_string(i) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -504,19 +504,19 @@ int TestPart1(int testNumber)
 
         if (it == itEnd)
             throw std::logic_error("iterators, push_front, non-full queue, begin and end should not be equal" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t i = 0;
         for ( ; it != itEnd; ++it, ++i)
         {
             if (*it != queue[i])
-                throw std::logic_error("iterators, push_front, non-full queue, value mismatch, got " + to_string(*it) + " expected: " + to_string(queue[i]) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("iterators, push_front, non-full queue, value mismatch, got " + TestHelpers::to_string(*it) + " expected: " + TestHelpers::to_string(queue[i]) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (i != queue.size())
-            throw std::logic_error("iterators, push_front, non-full queue, size mismatch, got " + to_string(i) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("iterators, push_front, non-full queue, size mismatch, got " + TestHelpers::to_string(i) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         std::cout << "	PASSED" << std::endl;
     }
@@ -538,8 +538,8 @@ int TestPart1(int testNumber)
         StackCircularQueue<int, queueSize> copy(queue);
 
         if (queue.size() != copy.size())
-            throw std::logic_error("copy constructor, full copy-from, size mismatch, got " + to_string(copy.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("copy constructor, full copy-from, size mismatch, got " + TestHelpers::to_string(copy.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = copy.begin();
@@ -547,8 +547,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != copy.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("copy constructor, full copy-from, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy constructor, full copy-from, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -571,8 +571,8 @@ int TestPart1(int testNumber)
         StackCircularQueue<int, queueSize> copy(queue);
 
         if (queue.size() != copy.size())
-            throw std::logic_error("copy constructor, not-full copy-from, size mismatch, got " + to_string(copy.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("copy constructor, not-full copy-from, size mismatch, got " + TestHelpers::to_string(copy.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = copy.begin();
@@ -580,8 +580,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != copy.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("copy constructor, not-full copy-from value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy constructor, not-full copy-from value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -601,8 +601,8 @@ int TestPart1(int testNumber)
         StackCircularQueue<int, queueSize> copy(queue);
 
         if (queue.size() != copy.size())
-            throw std::logic_error("copy constructor, empty copy-from, size mismatch, got " + to_string(copy.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("copy constructor, empty copy-from, size mismatch, got " + TestHelpers::to_string(copy.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = copy.begin();
@@ -610,8 +610,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != copy.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("copy constructor, empty copy-from value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy constructor, empty copy-from value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -636,8 +636,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, full copy-from, empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, full copy-from, empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -645,8 +645,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, full copy-from, empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, full copy-from, empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -671,8 +671,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, non-full copy-from, empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, non-full copy-from, empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -680,8 +680,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, non-full copy-from, empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, non-full copy-from, empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -702,8 +702,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, empty copy-from, empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, empty copy-from, empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -711,8 +711,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, empty copy-from, empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, empty copy-from, empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -738,8 +738,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, full copy-from, non-empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, full copy-from, non-empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -747,8 +747,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, full copy-from, non-empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, full copy-from, non-empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -774,8 +774,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, non-full copy-from, non-empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, non-full copy-from, non-empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -783,8 +783,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, non-full copy-from, non-empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, non-full copy-from, non-empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -807,8 +807,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, empty copy-from, non-empty copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, empty copy-from, non-empty copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -816,8 +816,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, empty copy-from, non-empty copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, empty copy-from, non-empty copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -845,8 +845,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, full copy-from, full copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, full copy-from, full copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -854,8 +854,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, full copy-from, full copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, full copy-from, full copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -882,8 +882,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, non-full copy-from, full copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, non-full copy-from, full copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -891,8 +891,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, non-full copy-from, full copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, non-full copy-from, full copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;
@@ -917,8 +917,8 @@ int TestPart1(int testNumber)
         assign = queue;
 
         if (queue.size() != assign.size())
-            throw std::logic_error("assignment, empty copy-from, full copy-to, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::logic_error("assignment, empty copy-from, full copy-to, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         StackCircularQueue<int, queueSize>::iterator itOriginal = queue.begin();
         StackCircularQueue<int, queueSize>::iterator itCopy = assign.begin();
@@ -926,8 +926,8 @@ int TestPart1(int testNumber)
         for ( ; itOriginal != queue.end() && itCopy != assign.end(); ++itOriginal, ++itCopy)
         {
             if (*itOriginal != *itCopy)
-                throw std::logic_error("assignment, empty copy-from, full copy-to, value mismatch, got " + to_string(*itCopy) + " expected: " + to_string(*itOriginal) + '\n'
-                + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("assignment, empty copy-from, full copy-to, value mismatch, got " + TestHelpers::to_string(*itCopy) + " expected: " + TestHelpers::to_string(*itOriginal) + '\n'
+                + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
 		std::cout << "	PASSED" << std::endl;

--- a/Toolkit/Arrays/StackCircularQueue/_Tests/test2.cpp
+++ b/Toolkit/Arrays/StackCircularQueue/_Tests/test2.cpp
@@ -12,13 +12,13 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 class EmplaceTwo
 {
     public:
-        EmplaceTwo(const std::string& name, const int number) : m_name(name), m_number(number), m_present (std::string(m_name) + " " + to_string(m_number)) {};
+        EmplaceTwo(const std::string& name, const int number) : m_name(name), m_number(number), m_present (std::string(m_name) + " " + TestHelpers::to_string(m_number)) {};
 		~EmplaceTwo() {};
 		
         bool operator==(const EmplaceTwo& other)
@@ -65,8 +65,8 @@ int StressTest(int testNumber)
 			queue.emplace_back(i);
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackCircularQueue<int, queueSize>::iterator it = queue.begin();
 		std::vector<int>::iterator iter = std.begin();
@@ -74,8 +74,8 @@ int StressTest(int testNumber)
 		for ( ; it != queue.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::logic_error("value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::logic_error("value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         StackCircularQueue<int, queueSize> assign;
@@ -85,12 +85,12 @@ int StressTest(int testNumber)
         assign = queue;
 
 		if (queue.size() != assign.size())
-			throw std::logic_error("size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		if (std.size() != assign.size())
-			throw std::logic_error("size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(std.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(std.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         it = assign.begin();
         iter = std.begin();
@@ -98,13 +98,13 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::logic_error("copy assignment, value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy assignment, value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::logic_error("copy assignment, size mismatch, got " + to_string(assign.size()) + " expected: " + to_string(std.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("copy assignment, size mismatch, got " + TestHelpers::to_string(assign.size()) + " expected: " + TestHelpers::to_string(std.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -131,16 +131,16 @@ int StressTest(int testNumber)
 			queue.push_back(i);
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackCircularQueue<int, queueSize>::iterator it = queue.begin();
 		std::vector<int>::iterator iter = std.begin();
 		for ( ; it != queue.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::logic_error("value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::logic_error("value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         StackCircularQueue<int, queueSize> assign;
@@ -150,8 +150,8 @@ int StressTest(int testNumber)
         assign = queue;
 
 		if (std.size() != assign.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(assign.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(assign.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         it = assign.begin();
         iter = std.begin();
@@ -159,13 +159,13 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::logic_error("copy assignment, value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy assignment, value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::logic_error("copy assignment, size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("copy assignment, size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -188,12 +188,12 @@ int StressTest(int testNumber)
 
 		for (int i = 0; i < 100; ++i)
 		{
-			std.push_back("big string the will require allocation on the heap " + to_string(i));
-			queue.emplace_back("big string the will require allocation on the heap " + to_string(i));
+			std.push_back("big string the will require allocation on the heap " + TestHelpers::to_string(i));
+			queue.emplace_back("big string the will require allocation on the heap " + TestHelpers::to_string(i));
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackCircularQueue<std::string, queueSize>::iterator it = queue.begin();
 		std::vector<std::string>::iterator iter = std.begin();
@@ -201,7 +201,7 @@ int StressTest(int testNumber)
 		{
 			if (*it != *iter)
 				throw std::logic_error("value mismatch, got '" + *it + "'\n expected: '" + *iter + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         StackCircularQueue<std::string, queueSize> assign("i like potatos on the heap if possible");
@@ -217,12 +217,12 @@ int StressTest(int testNumber)
         {
             if (*it != *iter)
                 throw std::logic_error("copy assignment, value mismatch, \ngot '" + *it + "'\n expected: '" + *iter + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
-			throw std::logic_error("copy assignment, size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(queue.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("copy assignment, size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(queue.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -256,8 +256,8 @@ int StressTest(int testNumber)
 		for ( ; it != queue.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (*it != *iter)
-				throw std::logic_error("value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::logic_error("value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
         StackCircularQueue<int, queueSize> assign(queue);
@@ -268,8 +268,8 @@ int StressTest(int testNumber)
         for ( ; it != assign.end() && iter != std.end(); ++it, ++iter)
         {
             if (*it != *iter)
-                throw std::logic_error("copy constructor, value mismatch, \ngot '" + to_string(*it) + "'\n expected: '" + to_string(*iter) + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+                throw std::logic_error("copy constructor, value mismatch, \ngot '" + TestHelpers::to_string(*it) + "'\n expected: '" + TestHelpers::to_string(*iter) + "'\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
         }
 
         if (std.size() != assign.size())
@@ -325,8 +325,8 @@ int StressTest(int testNumber)
 		}
 
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackCircularQueue<EmplaceTwo, queueSize>::iterator it = queue.begin();
 		std::vector<EmplaceTwo>::iterator iter = std.begin();
@@ -334,7 +334,7 @@ int StressTest(int testNumber)
 		{
 			if (*it != *iter)
 				throw std::logic_error("value mismatch, \ngot '" + it->present() + "'\n expected: '" + iter->present() + "'\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		std::cout << "	PASSED" << std::endl;

--- a/Toolkit/Arrays/StackCircularQueue/_Tests/test3.cpp
+++ b/Toolkit/Arrays/StackCircularQueue/_Tests/test3.cpp
@@ -12,7 +12,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 int TestPart3(int testNumber)
@@ -46,16 +46,16 @@ int TestPart3(int testNumber)
 			queue.push_front(new ToolkitBase(i));
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size())
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size())
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackCircularQueue<ToolkitBase*, queueSize>::iterator it = queue.begin();
 		std::list<ToolkitBase*>::iterator iter = std.begin();
 		for ( ; it != queue.end() && iter != std.end(); ++it, ++iter)
 		{
 			if (**it != **iter)
-				throw std::logic_error("value mismatch, got " + to_string((*it)->getValue()) + " expected: " + to_string((*iter)->getValue())
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::logic_error("value mismatch, got " + TestHelpers::to_string((*it)->getValue()) + " expected: " + TestHelpers::to_string((*iter)->getValue())
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		it = queue.begin();

--- a/Toolkit/Arrays/StackCircularQueue/_Tests/test4.cpp
+++ b/Toolkit/Arrays/StackCircularQueue/_Tests/test4.cpp
@@ -11,7 +11,7 @@
 # include "../../../_Tests/ToolkitDummy.hpp"
 # include "../../../_Tests/ToolkitBase.hpp"
 # include "../../../_Tests/ToolkitDerived.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 
 int TestPart4(int testNumber)
@@ -33,8 +33,8 @@ int TestPart4(int testNumber)
 			queue.push_front(i);
 		}
 		if (list.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(list.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(list.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackCircularQueue<int, queueSize>::iterator it = queue.begin();
 		std::list<int>::iterator iter = list.begin();
@@ -65,8 +65,8 @@ int TestPart4(int testNumber)
 			queue.push_back(i);
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackCircularQueue<ToolkitDummy, queueSize>::iterator it = queue.begin();
 		std::list<ToolkitDummy>::iterator iter = std.begin();
@@ -97,8 +97,8 @@ int TestPart4(int testNumber)
 			queue.emplace_back(i);
 		}
 		if (std.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(std.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(std.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		StackCircularQueue<ToolkitDummy, queueSize>::iterator it = queue.begin();
 		std::list<ToolkitDummy>::iterator iter = std.begin();
@@ -132,8 +132,8 @@ int TestPart4(int testNumber)
 			queue.emplace_back(i);
 		}
 		if (list.size() != queue.size())
-			throw std::logic_error("size mismatch, got " + to_string(queue.size()) + " expected: " + to_string(list.size()) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::logic_error("size mismatch, got " + TestHelpers::to_string(queue.size()) + " expected: " + TestHelpers::to_string(list.size()) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		StackCircularQueue<ToolkitDummy, queueSize>::iterator it = queue.begin();

--- a/Toolkit/List/_Tests/main.cpp
+++ b/Toolkit/List/_Tests/main.cpp
@@ -3,7 +3,7 @@
 // Project headers
 #include "../List.hpp"
 #include "../../_Tests/ToolkitDummy.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 // C++ headers
 #include <list>

--- a/Toolkit/List/_Tests/test1.cpp
+++ b/Toolkit/List/_Tests/test1.cpp
@@ -3,7 +3,7 @@
 // Project headers
 #include "../List.hpp"
 #include "../../_Tests/ToolkitDummy.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 // C++ headers
 #include <list>
@@ -41,7 +41,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	/************************ ************************/
@@ -72,7 +71,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	/******************* *** ************************/
@@ -103,7 +101,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	try
@@ -132,7 +129,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	/******************* *** ************************/
@@ -186,7 +182,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	/******************* *** ************************/
@@ -216,7 +211,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	/******************* *** ************************/
@@ -260,7 +254,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	/******************* *** ************************/
@@ -289,7 +282,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	/******************* *** ************************/
@@ -333,7 +325,6 @@ int TestPart1(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	return (testNumber);

--- a/Toolkit/List/_Tests/test2.cpp
+++ b/Toolkit/List/_Tests/test2.cpp
@@ -3,7 +3,7 @@
 // Project headers
 #include "../List.hpp"
 #include "../../_Tests/ToolkitDummy.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 // C++ headers
 #include <list>
@@ -43,7 +43,6 @@ int StressTest(int testNumber)
 	catch(const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 	
 
@@ -77,7 +76,6 @@ int StressTest(int testNumber)
 	catch(const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	return (testNumber);

--- a/Toolkit/List/_Tests/test3.cpp
+++ b/Toolkit/List/_Tests/test3.cpp
@@ -3,7 +3,7 @@
 // Project headers
 #include "../List.hpp"
 #include "../../_Tests/ToolkitDummy.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 // C++ headers
 #include <list>
@@ -47,7 +47,6 @@ int TestPart3(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /******************* *** ************************/
@@ -84,7 +83,6 @@ int TestPart3(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /******************* TEST ::erase() ************************/
@@ -129,7 +127,6 @@ int TestPart3(int testNumber)
     catch (const std::exception& e)
     {
         std::cout << "  FAILED: " << e.what() << std::endl;
-        TEST_FAIL_INFO();
     }
 
     return (testNumber);

--- a/Toolkit/MemoryPool/Heap_MemoryPool/_Tests/test1.cpp
+++ b/Toolkit/MemoryPool/Heap_MemoryPool/_Tests/test1.cpp
@@ -9,7 +9,7 @@
 // Project headers
 # include "../../Heap_MemoryPool/Heap_MemoryPool.hpp"
 # include "../../Nginx_PoolAllocator/Nginx_PoolAllocator.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 # include "TimerTrackerOld.hpp"
 
 int TestPart1(int testNumber)
@@ -52,9 +52,9 @@ int TestPart1(int testNumber)
 
         if (pool.getFreeSpace() != 4096 - 100 * sizeof(int))
             throw std::runtime_error("free space is not correct, got: " 
-            + to_string(pool.getFreeSpace()) + " expected: " 
-            + to_string(4096 - 100 * sizeof(int)) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::to_string(pool.getFreeSpace()) + " expected: " 
+            + TestHelpers::to_string(4096 - 100 * sizeof(int)) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;

--- a/Toolkit/MemoryPool/Heap_ObjectPool/_Tests/FixedElem_AllocCounter.tpp
+++ b/Toolkit/MemoryPool/Heap_ObjectPool/_Tests/FixedElem_AllocCounter.tpp
@@ -6,7 +6,7 @@
 
 #include "../Heap_ObjectPool.hpp"
 
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 template <typename T, typename Allocator = std::allocator<T> >
 class FixedElem_AllocCounter : public Heap_ObjectPool<T, Allocator>

--- a/Toolkit/MemoryPool/Heap_ObjectPool/_Tests/main.cpp
+++ b/Toolkit/MemoryPool/Heap_ObjectPool/_Tests/main.cpp
@@ -2,7 +2,7 @@
 #include "../Heap_ObjectPool.hpp"
 #include <list>
 
-#include "../../../_Tests/test.h"
+#include "../../../_Tests/TestHelpers.h"
 
 extern int TestPart1(int testNumber);
 extern int TestPart2(int testNumber);

--- a/Toolkit/MemoryPool/Heap_ObjectPool/_Tests/test1.cpp
+++ b/Toolkit/MemoryPool/Heap_ObjectPool/_Tests/test1.cpp
@@ -2,7 +2,7 @@
 
 // Project headers
 #include "../Heap_ObjectPool.hpp"
-#include "../../../_Tests/test.h"
+#include "../../../_Tests/TestHelpers.h"
 
 // C++ headers
 #include <map>
@@ -84,20 +84,19 @@ int TestPart1(int testNumber)
 		list1.clear();
 
 		if (counters[0] != counters[1])
-			throw std::runtime_error("alloc/dealloc count mismatch, allocs: " + to_string(counters[0]) 
-			+ " deallocs: " + to_string(counters[1]) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("alloc/dealloc count mismatch, allocs: " + TestHelpers::to_string(counters[0]) 
+			+ " deallocs: " + TestHelpers::to_string(counters[1]) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		if (counters[0] != expectedAllocCount)
-			throw std::runtime_error("alloc count failed, got " + to_string(counters[0]) 
-			+ " expected: " + to_string(expectedAllocCount) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("alloc count failed, got " + TestHelpers::to_string(counters[0]) 
+			+ " expected: " + TestHelpers::to_string(expectedAllocCount) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
 
@@ -131,20 +130,19 @@ int TestPart1(int testNumber)
 		map1.clear();
 
 		if (counters[0] != counters[1])
-			throw std::runtime_error("alloc/dealloc count mismatch, allocs: " + to_string(counters[0]) 
-			+ " deallocs: " + to_string(counters[1]) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("alloc/dealloc count mismatch, allocs: " + TestHelpers::to_string(counters[0]) 
+			+ " deallocs: " + TestHelpers::to_string(counters[1]) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		if (counters[0] != expectedAllocCount)
-			throw std::runtime_error("alloc count failed, got " + to_string(counters[0]) 
-			+ " expected: " + to_string(expectedAllocCount) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("alloc count failed, got " + TestHelpers::to_string(counters[0]) 
+			+ " expected: " + TestHelpers::to_string(expectedAllocCount) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	
 	return (testNumber);

--- a/Toolkit/MemoryPool/Heap_ObjectPool/_Tests/test2.cpp
+++ b/Toolkit/MemoryPool/Heap_ObjectPool/_Tests/test2.cpp
@@ -6,7 +6,7 @@
 
 # include "../../Nginx_MemoryPool/Nginx_MemoryPool.hpp"
 # include "../../Nginx_PoolAllocator/Nginx_PoolAllocator.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 // C++ headers
 # include <climits>
@@ -46,9 +46,9 @@ int TestPart2(int testNumber)
 
 		if (lastElement - firstElement != poolsize * nodeSize)
 		{
-			throw std::runtime_error("element size is not correct, got: " + to_string( lastElement - firstElement) 
-			+ " expected: " + to_string( poolsize * nodeSize ) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("element size is not correct, got: " + TestHelpers::to_string( lastElement - firstElement) 
+			+ " expected: " + TestHelpers::to_string( poolsize * nodeSize ) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		for (size_t i = 1; i < loopTimes; i++)
@@ -60,9 +60,9 @@ int TestPart2(int testNumber)
 			nodeAddress = (size_t)&(*it);
 			if (!(nodeAddress >= firstElement && nodeAddress < lastElement))
 			{
-				throw std::runtime_error("element  " + to_string((void *)nodeAddress) + " is outside range(" +
-				to_string((void *)firstElement) + ", " + to_string((void *)lastElement) + ")\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("element  " + TestHelpers::to_string((void *)nodeAddress) + " is outside range(" +
+				TestHelpers::to_string((void *)firstElement) + ", " + TestHelpers::to_string((void *)lastElement) + ")\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 			}
 		}
 
@@ -72,7 +72,6 @@ int TestPart2(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
 	std::cout << "TEST " << testNumber++ << ": ";
@@ -133,26 +132,26 @@ int TestPart2(int testNumber)
 		// List 1 must be allcoated in a block of this size
 		if (lastElement1 - firstElement1 != poolsize * nodeSize)
 		{
-			throw std::runtime_error("element size is not correct, got: " + to_string( lastElement1 - firstElement1) 
-			+ " expected: " + to_string( poolsize * nodeSize ) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("element size is not correct, got: " + TestHelpers::to_string( lastElement1 - firstElement1) 
+			+ " expected: " + TestHelpers::to_string( poolsize * nodeSize ) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		// List2 must be allcoated in a block of this size
 		if (lastElement2 - firstElement2 != poolsize * nodeSize)
 		{
-			throw std::runtime_error("element size is not correct, got: " + to_string( lastElement2 - firstElement2) 
-			+ " expected: " + to_string( poolsize * nodeSize ) + '\n'
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			throw std::runtime_error("element size is not correct, got: " + TestHelpers::to_string( lastElement2 - firstElement2) 
+			+ " expected: " + TestHelpers::to_string( poolsize * nodeSize ) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		// blocks don't overlap
 		if (lastElement1 > firstElement2)
 		{
 			throw std::runtime_error(std::string("blocks are overlapping: \n")
-			+ "\tfirst block: (" + to_string((void *)firstElement1) + ", " + to_string((void *)lastElement1) + ")\n"
-			+ "\tsecnd block: (" + to_string((void *)firstElement2) + ", " + to_string((void *)lastElement2) + ")\n"
-			+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+			+ "\tfirst block: (" + TestHelpers::to_string((void *)firstElement1) + ", " + TestHelpers::to_string((void *)lastElement1) + ")\n"
+			+ "\tsecnd block: (" + TestHelpers::to_string((void *)firstElement2) + ", " + TestHelpers::to_string((void *)lastElement2) + ")\n"
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 		}
 
 		/////////////////////
@@ -166,9 +165,9 @@ int TestPart2(int testNumber)
 			nodeAddress = (size_t)&(*it);
 			if (!(nodeAddress >= firstElement1 && nodeAddress < lastElement1))
 			{
-				throw std::runtime_error("element  " + to_string((void *)nodeAddress) + " is outside range(" +
-				to_string((void *)firstElement1) + ", " + to_string((void *)lastElement1) + ")\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("element  " + TestHelpers::to_string((void *)nodeAddress) + " is outside range(" +
+				TestHelpers::to_string((void *)firstElement1) + ", " + TestHelpers::to_string((void *)lastElement1) + ")\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 			}
 		}
 
@@ -181,9 +180,9 @@ int TestPart2(int testNumber)
 			nodeAddress = (size_t)&(*it);
 			if (!(nodeAddress >= firstElement2 && nodeAddress < lastElement2))
 			{
-				throw std::runtime_error("element  " + to_string((void *)nodeAddress) + " is outside range(" +
-				to_string((void *)firstElement2) + ", " + to_string((void *)lastElement2) + ")\n"
-				+ FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+				throw std::runtime_error("element  " + TestHelpers::to_string((void *)nodeAddress) + " is outside range(" +
+				TestHelpers::to_string((void *)firstElement2) + ", " + TestHelpers::to_string((void *)lastElement2) + ")\n"
+				+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 			}
 		}
 

--- a/Toolkit/MemoryPool/Nginx_MemoryPool/_Tests/test1.cpp
+++ b/Toolkit/MemoryPool/Nginx_MemoryPool/_Tests/test1.cpp
@@ -10,7 +10,7 @@
 # include "../Nginx_MemoryPool.hpp"
 # include "../../Nginx_PoolAllocator/Nginx_PoolAllocator.hpp"
 # include "../../Heap_ObjectPool/Heap_ObjectPool.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 # include "TestAllocator.tpp"
 
 int TestPart1(int testNumber)
@@ -54,14 +54,14 @@ int TestPart1(int testNumber)
         Impl_Nginx_MemoryPool<t_byte, TestAllocator<t_byte> > pool(4096, 1, alloc);
 
         if (counters[TestAllocator<t_byte>::E_ALLOC_COUNT] != 1)
-            throw std::runtime_error("alloc count dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
+            throw std::runtime_error("alloc count dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
              + " expected 1" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (counters[TestAllocator<t_byte>::E_ALLOC_BYTES] != 4096)
-            throw std::runtime_error("alloc bytes dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
+            throw std::runtime_error("alloc bytes dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
              + " expected 4096" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -86,14 +86,14 @@ int TestPart1(int testNumber)
 
         //same result, didn't overwelm the pool
         if (counters[TestAllocator<t_byte>::E_ALLOC_COUNT] != 1)
-            throw std::runtime_error("alloc count dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
+            throw std::runtime_error("alloc count dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
              + " expected 1" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (counters[TestAllocator<t_byte>::E_ALLOC_BYTES] != 100 * (sizeof(int)))
-            throw std::runtime_error("alloc bytes dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
+            throw std::runtime_error("alloc bytes dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
              + " expected 4096" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
         void* bigBlock = pool.allocate(200);
@@ -102,15 +102,15 @@ int TestPart1(int testNumber)
         //big block, will overwelm the pool
 
         if (counters[TestAllocator<t_byte>::E_ALLOC_COUNT] != 2)
-            throw std::runtime_error("alloc count dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
+            throw std::runtime_error("alloc count dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
              + " expected 1" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t expectedBytes = (100 + 200 + 16 / sizeof(int)) * (sizeof(int)); //16 / sizeof(int)(how many ints i have to allocate to have place for the big block struct)
         if (counters[TestAllocator<t_byte>::E_ALLOC_BYTES] != expectedBytes)
-            throw std::runtime_error("alloc bytes dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
-             + " expected " + to_string(expectedBytes) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::runtime_error("alloc bytes dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
+             + " expected " + TestHelpers::to_string(expectedBytes) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -139,14 +139,14 @@ int TestPart1(int testNumber)
 
         //same result, didn't overwelm the pool
         if (counters[TestAllocator<t_byte>::E_ALLOC_COUNT] != 1)
-            throw std::runtime_error("alloc count dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
+            throw std::runtime_error("alloc count dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
              + " expected 1" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (counters[TestAllocator<t_byte>::E_ALLOC_BYTES] != 4096)
-            throw std::runtime_error("alloc bytes dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
+            throw std::runtime_error("alloc bytes dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
              + " expected 4096" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         // inserting integers
         for (size_t i = 0; i < 100; ++i)
@@ -155,14 +155,14 @@ int TestPart1(int testNumber)
 
         // should not trigger any call to new, there is plenty of space in the first block of the pool
         if (counters[TestAllocator<t_byte>::E_ALLOC_COUNT] != 1)
-            throw std::runtime_error("alloc count dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
+            throw std::runtime_error("alloc count dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
              + " expected 1" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (counters[TestAllocator<t_byte>::E_ALLOC_BYTES] != 4096)
-            throw std::runtime_error("alloc bytes dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
+            throw std::runtime_error("alloc bytes dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
              + " expected 4096" + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -190,14 +190,14 @@ int TestPart1(int testNumber)
         monitoredList       list(objPool);
 
         if (counters[TestAllocator<t_byte>::E_ALLOC_COUNT] != 1)
-            throw std::runtime_error("alloc count dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
-             + " expected " + to_string(1) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::runtime_error("alloc count dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
+             + " expected " + TestHelpers::to_string(1) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         if (counters[TestAllocator<t_byte>::E_ALLOC_BYTES] != 4096)
-            throw std::runtime_error("alloc bytes dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
-             + " expected " + to_string(4096) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::runtime_error("alloc bytes dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
+             + " expected " + TestHelpers::to_string(4096) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         // inserting integers
         for (size_t i = 0; i < 200; ++i)
@@ -206,15 +206,15 @@ int TestPart1(int testNumber)
 
         // should not trigger any call to new, there is plenty of space in the first block of the pool
         if (counters[TestAllocator<t_byte>::E_ALLOC_COUNT] != 2)
-            throw std::runtime_error("alloc count dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
-             + " expected " + to_string(2) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::runtime_error("alloc count dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_COUNT])
+             + " expected " + TestHelpers::to_string(2) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         size_t expectedBytes = 4096 + 200 * 24 + 4 * 4; //base alloc + 200 list nodes + 4 integers to fit t_bigBlock struct
         if (counters[TestAllocator<t_byte>::E_ALLOC_BYTES] != expectedBytes)
-            throw std::runtime_error("alloc bytes dont match, got " + to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
-             + " expected " + to_string(expectedBytes) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            throw std::runtime_error("alloc bytes dont match, got " + TestHelpers::to_string(counters[TestAllocator<t_byte>::E_ALLOC_BYTES])
+             + " expected " + TestHelpers::to_string(expectedBytes) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}

--- a/Toolkit/MemoryPool/Nginx_PoolAllocator/_Tests/test1.cpp
+++ b/Toolkit/MemoryPool/Nginx_PoolAllocator/_Tests/test1.cpp
@@ -10,7 +10,7 @@
 # include "../../Nginx_MemoryPool/Nginx_MemoryPool.hpp"
 # include "../../Heap_MemoryPool/Heap_MemoryPool.hpp"
 # include "../../Nginx_PoolAllocator/Nginx_PoolAllocator.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 int TestPart1(int testNumber)
 {
@@ -54,9 +54,9 @@ int TestPart1(int testNumber)
 
         if (pool.getFreeSpace() != 4096 - 100 * sizeof(int))
             throw std::runtime_error("free space is not correct, got: " 
-            + to_string(pool.getFreeSpace()) + " expected: " 
-            + to_string(4096 - 100 * sizeof(int)) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::to_string(pool.getFreeSpace()) + " expected: " 
+            + TestHelpers::to_string(4096 - 100 * sizeof(int)) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;

--- a/Toolkit/MemoryPool/Stack_MemoryPool/_Tests/test1.cpp
+++ b/Toolkit/MemoryPool/Stack_MemoryPool/_Tests/test1.cpp
@@ -13,7 +13,7 @@
 # include "../../Nginx_MemoryPool/Nginx_MemoryPool.hpp"
 # include "../../Nginx_PoolAllocator/Nginx_PoolAllocator.hpp"
 # include "../../Heap_ObjectPool/Heap_ObjectPool.hpp"
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 int TestPart1(int testNumber)
 {
@@ -56,9 +56,9 @@ int TestPart1(int testNumber)
 
         if (pool.getFreeSpace() != 4096 - 100 * sizeof(int))
             throw std::runtime_error("free space is not correct, got: " 
-            + to_string(pool.getFreeSpace()) + " expected: " 
-            + to_string(4096 - 100 * sizeof(int)) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::to_string(pool.getFreeSpace()) + " expected: " 
+            + TestHelpers::to_string(4096 - 100 * sizeof(int)) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
 		std::cout << "	PASSED" << std::endl;
@@ -81,18 +81,18 @@ int TestPart1(int testNumber)
 
         if (pool.getFreeSpace() != 4096)
             throw std::runtime_error("free space is not correct, got: " 
-            + to_string(pool.getFreeSpace()) + " expected: " 
-            + to_string(4096 - 100 * sizeof(int)) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::to_string(pool.getFreeSpace()) + " expected: " 
+            + TestHelpers::to_string(4096 - 100 * sizeof(int)) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
         list.push_back("big string that mallocs just to be sure that RAII is working");
         list.push_back("fits buf");
 
         if (pool.getFreeSpace() != 4096 - 2 * (sizeof(std::string) + 8 + 8))
             throw std::runtime_error("free space is not correct, got: " 
-            + to_string(pool.getFreeSpace()) + " expected: " 
-            + to_string(4096 - 2 * (sizeof(int) + 4 + 8 + 8)) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::to_string(pool.getFreeSpace()) + " expected: " 
+            + TestHelpers::to_string(4096 - 2 * (sizeof(int) + 4 + 8 + 8)) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}
@@ -120,9 +120,9 @@ int TestPart1(int testNumber)
 
         if (pool.getFreeSpace() != poolSize)
             throw std::runtime_error("free space is not correct, got: " 
-            + to_string(pool.getFreeSpace()) + " expected: " 
-            + to_string(4096 - 100 * sizeof(int)) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::to_string(pool.getFreeSpace()) + " expected: " 
+            + TestHelpers::to_string(4096 - 100 * sizeof(int)) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 
         for (int i = 0; i < elementCount; i++)
@@ -130,9 +130,9 @@ int TestPart1(int testNumber)
 
         if (pool.getFreeSpace() != 0)
             throw std::runtime_error("free space is not correct, got: " 
-            + to_string(pool.getFreeSpace()) + " expected: " 
-            + to_string(4096 - 2 * (sizeof(int) + 4 + 8 + 8)) + '\n'
-            + FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+            + TestHelpers::to_string(pool.getFreeSpace()) + " expected: " 
+            + TestHelpers::to_string(4096 - 2 * (sizeof(int) + 4 + 8 + 8)) + '\n'
+            + TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
 
 		std::cout << "	PASSED" << std::endl;
 	}

--- a/Toolkit/MemoryPool/Stack_ObjectPool/_Tests/FixedElem_AllocCounter.tpp
+++ b/Toolkit/MemoryPool/Stack_ObjectPool/_Tests/FixedElem_AllocCounter.tpp
@@ -6,7 +6,7 @@
 
 #include "../Stack_ObjectPool.hpp"
 
-# include "../../../_Tests/test.h"
+# include "../../../_Tests/TestHelpers.h"
 
 template <typename T, size_t Size>
 class FixedElem_AllocCounter : public Stack_ObjectPool<T, Size>

--- a/Toolkit/MemoryPool/Stack_ObjectPool/_Tests/main.cpp
+++ b/Toolkit/MemoryPool/Stack_ObjectPool/_Tests/main.cpp
@@ -3,7 +3,7 @@
 #include "../Stack_ObjectPool.hpp"
 #include <list>
 
-#include "../../../_Tests/test.h"
+#include "../../../_Tests/TestHelpers.h"
 
 
 int main(void)

--- a/Toolkit/MemoryPool/_Demo/main.cpp
+++ b/Toolkit/MemoryPool/_Demo/main.cpp
@@ -11,7 +11,7 @@
 # include "../Nginx_MemoryPool/Nginx_MemoryPool.hpp"
 # include "../Nginx_PoolAllocator/Nginx_PoolAllocator.hpp"
 # include "../Heap_ObjectPool/Heap_ObjectPool.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 /*
 
@@ -138,7 +138,7 @@ int main(void)
         {
             vec[i].erase(vec[i].size() - 3);
             vec[i] += " ";
-            vec[i] += to_string(i).c_str();
+            vec[i] += TestHelpers::to_string(i).c_str();
             
             std::cout << vec[i];
             vec[i] = " potato";

--- a/Toolkit/ThreadPool/_Tests/main.cpp
+++ b/Toolkit/ThreadPool/_Tests/main.cpp
@@ -8,7 +8,7 @@
 # include "../../_Tests/ToolkitDummy.hpp"
 # include "../../_Tests/ToolkitBase.hpp"
 # include "../../_Tests/ToolkitDerived.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 // C++ headers
 # include <unistd.h>

--- a/Toolkit/ThreadPool/_Tests/test1.cpp
+++ b/Toolkit/ThreadPool/_Tests/test1.cpp
@@ -8,7 +8,7 @@
 # include "../../_Tests/ToolkitDummy.hpp"
 # include "../../_Tests/ToolkitBase.hpp"
 # include "../../_Tests/ToolkitDerived.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 // C++ headers
 # include <unistd.h>
@@ -64,7 +64,6 @@ int	TestPart1(int testNumber)
 	catch(const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	testNumber++;
 
@@ -81,7 +80,6 @@ int	TestPart1(int testNumber)
 	catch(const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	testNumber++;
 
@@ -120,7 +118,6 @@ int	TestPart1(int testNumber)
 	catch(const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	testNumber++;
 

--- a/Toolkit/ThreadPool/_Tests/test2.cpp
+++ b/Toolkit/ThreadPool/_Tests/test2.cpp
@@ -15,7 +15,7 @@
 # include "../../_Tests/ToolkitDummy.hpp"
 # include "../../_Tests/ToolkitBase.hpp"
 # include "../../_Tests/ToolkitDerived.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 static long fibGood(unsigned int n)
 {
@@ -88,7 +88,6 @@ int StressTest(int testNumber)
 	catch(const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	testNumber++;	
 	return (testNumber);

--- a/Toolkit/ThreadPool/_Tests/test3.cpp
+++ b/Toolkit/ThreadPool/_Tests/test3.cpp
@@ -8,7 +8,7 @@
 # include "../../_Tests/ToolkitDummy.hpp"
 # include "../../_Tests/ToolkitBase.hpp"
 # include "../../_Tests/ToolkitDerived.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 // C++ headers
 # include <unistd.h>
@@ -165,7 +165,6 @@ int TestPart3(int testNumber)
 	catch(const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	testNumber++;	
 	return (testNumber);

--- a/Toolkit/ThreadPool/_Tests/test4.cpp
+++ b/Toolkit/ThreadPool/_Tests/test4.cpp
@@ -8,7 +8,7 @@
 # include "../../_Tests/ToolkitDummy.hpp"
 # include "../../_Tests/ToolkitBase.hpp"
 # include "../../_Tests/ToolkitDerived.hpp"
-# include "../../_Tests/test.h"
+# include "../../_Tests/TestHelpers.h"
 
 // C++ headers
 # include <unistd.h>
@@ -93,7 +93,6 @@ int TestPart4(int testNumber)
 	catch(const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 	return (testNumber);
 }

--- a/Toolkit/_Tests/Integration/DynArrayMemPool.cpp
+++ b/Toolkit/_Tests/Integration/DynArrayMemPool.cpp
@@ -37,7 +37,6 @@ int DynArrayMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
 /******************* TEST 5 ************************/
@@ -96,7 +95,6 @@ int DynArrayMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
 
 
@@ -184,7 +182,6 @@ int DynArrayMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
     testNumber++;
 

--- a/Toolkit/_Tests/Integration/HeapArrayMemPool.cpp
+++ b/Toolkit/_Tests/Integration/HeapArrayMemPool.cpp
@@ -63,8 +63,7 @@ int testHeapArrayMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
-	}
+        	}
     testNumber++;
 
 /*******************  *****************************/
@@ -149,7 +148,6 @@ int testHeapArrayMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
     testNumber++;
 
@@ -184,7 +182,6 @@ int testHeapArrayMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-        TEST_FAIL_INFO();
 	}
     testNumber++;
 

--- a/Toolkit/_Tests/Integration/ListMemPool.cpp
+++ b/Toolkit/_Tests/Integration/ListMemPool.cpp
@@ -37,7 +37,6 @@ int ListMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /********************************************* */
@@ -72,7 +71,6 @@ int ListMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /******************* *** ************************/
@@ -131,8 +129,7 @@ int ListMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
-    }
+		    }
 
 
 /******************* *** ************************/
@@ -175,7 +172,6 @@ int ListMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 	/******************* *** ************************/
@@ -233,7 +229,6 @@ int ListMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /******************* *** ************************/
@@ -270,7 +265,6 @@ int ListMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /******************* *** ************************/
@@ -307,7 +301,6 @@ int ListMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /******************* *** ************************/
@@ -344,7 +337,6 @@ int ListMemPool(int testNumber)
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 try
@@ -404,7 +396,6 @@ try
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /****************************************************** */
@@ -477,7 +468,6 @@ try
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /********************************************************* */
@@ -529,7 +519,6 @@ try
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 /******************************************************** */
@@ -586,7 +575,6 @@ try
 	catch (const std::exception& e)
 	{
 		std::cout << "	FAILED: " << e.what()  << std::endl;
-		TEST_FAIL_INFO();
 	}
 
 

--- a/Toolkit/_Tests/TestHelpers.h
+++ b/Toolkit/_Tests/TestHelpers.h
@@ -1,0 +1,27 @@
+
+
+#ifndef TEST_H
+
+# define TEST_H
+
+# include <iostream>
+# include <iomanip>
+# include <sstream>
+# include <string>
+
+namespace TestHelpers
+{
+	template <typename T>
+	std::string to_string(const T& value)
+	{
+		std::ostringstream oss;
+		oss << value;
+		return oss.str();
+	}
+
+
+	std::string FileLineFunction(const char* file, const int line, const char* function);
+}
+
+
+#endif

--- a/Toolkit/_Tests/testHelpers.cpp
+++ b/Toolkit/_Tests/testHelpers.cpp
@@ -1,8 +1,8 @@
 
 
-# include "test.h"
+# include "TestHelpers.h"
 
-std::string FileLineFunction(const char* file, const int line, const char* function)
+std::string TestHelpers::FileLineFunction(const char* file, const int line, const char* function)
 {
-    return std::string("\tFile: ") + file + "\n\tLine: " + to_string(line) + "\n\tFunction: " + function + '\n';
+    return std::string("\tFile: ") + file + "\n\tLine: " + TestHelpers::to_string(line) + "\n\tFunction: " + function + '\n';
 }

--- a/Toolkit/_WIP/SmartPointers/Tests/mainfd.cpp
+++ b/Toolkit/_WIP/SmartPointers/Tests/mainfd.cpp
@@ -9,8 +9,10 @@
 
 int main(void)
 {
-    UniquePtr<FileDescriptor> fd1 = FdCreators::open("main2.cpp", O_RDONLY);
-    UniquePtr<FileDescriptor> fd2 = FdCreators::open("mainfd.cpp", O_RDONLY);
+    UniquePtr<FileDescriptor
+> fd1 = FdCreators::open("main2.cpp", O_RDONLY);
+    UniquePtr<FileDescriptor
+> fd2 = FdCreators::open("mainfd.cpp", O_RDONLY);
 
     char buffer[3024];
 

--- a/Webserv/EventCallback/EventCallback.cpp
+++ b/Webserv/EventCallback/EventCallback.cpp
@@ -1,0 +1,37 @@
+
+
+# include "EventCallback.hpp"
+# include <cassert>
+# include <cstddef>
+
+EventCallback::EventCallback() :
+	m_fd				(-1),
+	m_monitoredEvents	(Ws::Epoll::NONE),
+	m_triggeredEvents	(Ws::Epoll::NONE),
+	m_user				(NULL),
+	m_handler			(NULL),
+	m_subscribedFd		(-1),
+	m_subscribedEvents	(Ws::Epoll::NONE)
+{}
+
+EventCallback::~EventCallback() {}
+
+
+void EventCallback::handle()
+{
+	if (m_handler)
+		m_handler(*this);
+}
+
+void	EventCallback::reset()
+{
+	m_fd = -1;
+	m_monitoredEvents = Ws::Epoll::NONE;
+	m_triggeredEvents = Ws::Epoll::NONE;
+	m_user = NULL;
+	m_handler = NULL;
+}
+
+//private
+EventCallback::EventCallback(const EventCallback& copy)  {(void)copy;}
+EventCallback& EventCallback::operator=(const EventCallback& assign) {(void)assign; return (*this);}

--- a/Webserv/EventCallback/EventCallback.hpp
+++ b/Webserv/EventCallback/EventCallback.hpp
@@ -1,0 +1,57 @@
+
+
+#ifndef EVENTCALLBACK_HPP
+
+# define EVENTCALLBACK_HPP
+
+# include "../GenericUtils/Webserver_Definitions.h"
+
+class EventCallback
+{
+	public:
+
+		typedef void* 				User;
+		typedef void 				(*Handler)(EventCallback& event);
+
+		EventCallback();
+		~EventCallback();
+
+		//methods
+		void						handle();
+		void						reset();
+
+		// accessors
+		EventCallback::User			accessUser();
+		EventCallback::Handler		accessHandler();
+
+		//getters
+		Ws::fd						getFd()						const;
+		Ws::Epoll::Events			getMonitoredEvents()		const;
+		Ws::Epoll::Events			getTriggeredEvents()		const;
+
+		//setters
+		void						setFd				(const Ws::fd fd);
+		void						setMonitoredEvents	(const Ws::Epoll::Events flags);
+		void						setUser				(const EventCallback::User data);
+		void						setHandler			(const EventCallback::Handler handler);
+		void						setUserHandler		(const EventCallback::User data, const EventCallback::Handler handler);	
+		// no setter for triggeredFlags, it is EventManager who sets those
+
+		
+	protected:
+		Ws::fd						m_fd;
+		Ws::Epoll::Events			m_monitoredEvents;
+		Ws::Epoll::Events			m_triggeredEvents;
+		EventCallback::User			m_user;
+		EventCallback::Handler		m_handler;
+		
+		EventCallback(const EventCallback& copy);
+		EventCallback& operator=(const EventCallback& assign);
+
+
+		//for internal use
+		Ws::fd						m_subscribedFd;
+		Ws::Epoll::Events			m_subscribedEvents;
+};
+
+#endif

--- a/Webserv/EventCallback/EventCallbackGetSetAccess.cpp
+++ b/Webserv/EventCallback/EventCallbackGetSetAccess.cpp
@@ -1,0 +1,61 @@
+
+
+# include "EventCallback.hpp"
+
+// accessors
+
+
+EventCallback::User				EventCallback::accessUser()
+{
+	return (m_user);
+}
+
+EventCallback::Handler			EventCallback::accessHandler()
+{
+	return (m_handler);
+}
+
+// getters
+
+Ws::fd						EventCallback::getFd() const
+{
+	return (m_fd);
+}
+
+Ws::Epoll::Events			EventCallback::getMonitoredEvents() const
+{
+	return (m_monitoredEvents);
+}
+
+Ws::Epoll::Events			EventCallback::getTriggeredEvents() const
+{
+	return (m_monitoredEvents);
+}
+
+// setters
+
+void	EventCallback::setFd(const Ws::fd fd)
+{
+	m_fd = fd;
+}
+
+void	EventCallback::setMonitoredEvents(const Ws::Epoll::Events flags)
+{
+	m_monitoredEvents = flags;
+}
+
+void	EventCallback::setUser(const EventCallback::User user)
+{
+	m_user = user;
+}
+
+void	EventCallback::setHandler(const EventCallback::Handler handler)
+{
+	m_handler = handler;
+}
+
+void	EventCallback::setUserHandler(const EventCallback::User user, const EventCallback::Handler handler)
+{
+	m_user = user;
+	m_handler = handler;
+}

--- a/Webserv/EventCallback/_EventCallback.docs
+++ b/Webserv/EventCallback/_EventCallback.docs
@@ -1,0 +1,157 @@
+
+
+EventCallback is what wraps the handling of events.
+
+EventCallbacks are to be subscribed to the EventManager to monitor.
+
+When the EventManager detects an event on the file descriptor
+to which EventCallback is assigned, it calls EventCallback::handle()
+to execute the action (Callback) as a response to that event.
+
+This "action" is essentially a function pointer that takes the EventCallback itself as an argument.
+"Why?" to retain flexibility and allow us to use void* without pissing off the compiler.
+
+EventCallback::Handler is [void (*Handler)(EventCallback& event)]
+
+We need this intermediary step because the EventCallback knows nothing about its users:
+	-> it can't typecast the m_user to the correct type.
+
+So flexibility implies the user must actually follow something along these lines:
+
+Example:
+
+
+#################################
+class User
+{
+	public:
+		void doSomething()
+		{
+			m_data = 42;
+		}
+
+		static void MyCallback_doSomething(EventCallback& event)
+		{
+			user* me = reinterpret_cast<user*>(&event.accessUser());
+			me->doSomething();
+		}
+
+		int getData() const
+		{
+			return (m_data);
+		}
+	private
+		int	m_data;
+}
+
+when we setup the EventCallback, we will do:
+
+User			user;
+EventCallback 	callback;
+
+callback.setUser(user);
+callback.setHandler(&User::MyCallback_doSomething);
+
+callback.handle();
+
+assert(user.getData() == 42); <- should be true
+
+#####################################
+
+So the function pointer cannot be a member function. We could do this with polymorphism but
+no thanks.
+
+The user supplies a static member function that internally typecasts the EventCallback::m_user
+to its own type and calls its own method to be executed.
+
+So like this, we decoupled the EventCallback from the actual users.
+
+Notice though, THERE IS NO TYPESAFETY HERE.
+The programmer must supply a user and a handler that match, otherwise be ready for chaos.
+
+
+###################################
+
+In handle, the EventCallback just checks that a handler exists and not a User.
+The reason being, maybe the handler does not need any external data to do what it has to do.
+Maybe it accesses globals, or maybe it just prints to std::cout.
+
+so if you want to pass a handler say:
+
+void	SomeHandler(EventCallback& callback)
+{
+	(void)callback;
+
+	std::cout << "Hello World!" << std::endl;
+}
+
+EventCallback callback;
+
+callback.setHandler(&SomeHandler);
+
+callback.handle();
+
+##################################
+
+Ok so the above is the callback part. Now we get to the event part.
+This class serves to execute an action based on an event that happpened.
+In our setup, the "events" are simply, input and output on file descriptors.
+This class doesn't track anything, simple "reactsJS" to an event that happened.
+
+Still whoever tracks the event must have a file descriptor to monitor and some
+event types to monitor (read, write, hang-up).
+
+We are using epoll as our event monitor so we pass the relevant file descriptor
+and the epollflags we want to monitor (Ws::Epoll).
+
+In a real context, the EventCallback::Handler would be something like HttpRead,
+the EventCallback::User would be HttpConnection, the fd would be the Client socket,
+and the flags would be Ws::Epoll::READ and Ws::Epoll::WRITE.
+
+######################################
+
+Member Functions:
+
+		//methods
+		void						handle();			//handles the subscribed event
+		void						reset();			//sets all internals back to "empty"
+
+		// accessors
+		EventCallback::User			accessUser();		//allow the caller to access the User and then typecast it
+		EventCallback::Handler		accessHandler();	//The function pointer that will be called
+
+		//getters
+		Ws::fd						getFd()						const;		
+		Ws::Epoll::Events			getMonitoredEvents()		const;		//the events we are asking to monitor (read, write)
+		Ws::Epoll::Events			getTriggeredEvents()		const;		//the events that resulted in the EventCallback being called
+																			//(this value will be set by EventManager, letting us know "what happened")
+
+		//setters
+		void						setFd				(const Ws::fd fd);
+		void						setMonitoredEvents	(const Ws::Epoll::Events flags);
+		void						setUser				(const EventCallback::User data);
+		void						setHandler			(const EventCallback::Handler handler);
+		void						setUserHandler		(const EventCallback::User data, const EventCallback::Handler handler);	
+
+
+##############################################
+
+Design considerations
+
+No setters for triggered flags are provided:
+the user is not supposed to set this value.
+
+Internally, our EventsManager will set these flags when processing events, by having
+an InternalEventCallback that inherits from this one and adds the relevant flags to it.
+
+We do opt to still allocate space for these extra member variables in the base class itself
+just not to have to copy events all the time, we use the same base instance and
+inherit from it to modify the remaining parts.
+
+So, a user could still messup the class but either the EventManager would have to be the sole supplier
+of Events or we would have to do a lot of copying for very little gain.
+
+In CgiModule, the Cgi::Module will be the sole supplier of Cgi::Request which allows a more clear separation
+as we expose the public part of Request to the User while having access to extra internals.
+
+##########################################

--- a/Webserv/EventCallback/_Tests/Makefile
+++ b/Webserv/EventCallback/_Tests/Makefile
@@ -1,0 +1,50 @@
+
+
+# Compiler and flags
+CXX 		=	c++
+CXXFLAGS 	= 	-Wall -Wextra -Werror -g -std=c++98 -MMD -MP
+NAME 		= 	test.out
+
+# Paths
+ROOT_PATH	=	$(shell git rev-parse --show-toplevel)
+SRC_PATH	=	$(ROOT_PATH)/.
+OBJ_PATH	=	$(ROOT_PATH)/_build
+
+# Sources
+SRCS	    =   $(SRC_PATH)/Webserv/EventCallback/EventCallback.cpp \
+				$(SRC_PATH)/Webserv/EventCallback/EventCallbackGetSetAccess.cpp \
+				\
+				$(SRC_PATH)/Webserv/EventCallback/_Tests/main.cpp \
+				\
+				$(SRC_PATH)/Toolkit/_Tests/testHelpers.cpp
+
+
+OBJS 		= 	$(patsubst $(SRC_PATH)/%.cpp, $(OBJ_PATH)/%.o, $(SRCS))
+DEPS 		= 	$(OBJS:.o=.d)
+
+#####################################################
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) $(OBJS) -o $(NAME)
+
+$(OBJ_PATH)/%.o: $(SRC_PATH)/%.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+-include $(DEPS)
+
+#####################################################
+
+all: $(NAME)
+
+test: $(NAME)
+	@valgrind --quiet --leak-check=full --errors-for-leak-kinds=all --show-leak-kinds=all  ./$(NAME)
+
+clean:
+	rm -rf $(NAME) vgcore*
+
+fclean: clean
+
+re: fclean all
+
+.PHONY: clean fclean run

--- a/Webserv/EventCallback/_Tests/main.cpp
+++ b/Webserv/EventCallback/_Tests/main.cpp
@@ -1,0 +1,126 @@
+
+
+// Test subject
+# include "../EventCallback.hpp"
+
+//Project headers
+# include "../../../Toolkit/_Tests/TestHelpers.h"
+# include "../../GenericUtils/StringUtils/StringUtils.hpp"
+# include <iostream>
+# include <cstdio>
+# include <unistd.h>
+
+class User
+{
+	public:
+		void doSomething()
+		{
+			m_data = 42;
+		}
+
+		static void MyCallback_doSomething(EventCallback& event)
+		{
+			User* me = reinterpret_cast<User*>(event.accessUser());
+			me->doSomething();
+		}
+
+		int getData() const
+		{
+			return (m_data);
+		}
+
+	private:
+		int	m_data;
+};
+
+void	PrintHelloWorld(EventCallback& callback)
+{
+	(void)callback;
+
+	std::cout << "Hello World!";
+	std::cout.flush();
+}
+
+
+
+int main(void)
+{
+	int testNumber = 1;
+
+	std::cout << "\n*************** EventCallback tests ***************" << std::endl;
+
+	try
+	{
+
+		std::cout << "TEST " << testNumber++ << ": ";
+
+		User			user;
+		EventCallback 	callback;
+
+		callback.setUser(&user);
+		callback.setHandler(&User::MyCallback_doSomething);
+
+		callback.handle();
+
+		assert(user.getData() == 42);
+
+		if (user.getData() != 42)
+			throw std::runtime_error("EventCallback failed to handle, got " 
+			+ StringUtils::to_string(user.getData()) + ", expected " 
+			+ StringUtils::to_string(42) + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+		
+		std::cout << "	PASSED (passing a static member function that typecasts the User and performs a user action)" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "	FAILED: " << e.what()  << std::endl;
+	}
+
+	try
+	{
+
+		std::cout << "TEST " << testNumber++ << ": ";
+		std::cout.flush();
+
+		//some pipes to capture stdout
+		int pipefd[2];
+		int duplicate = dup(STDOUT_FILENO);
+		pipe(pipefd);
+		dup2(pipefd[1], STDOUT_FILENO);
+
+		////// Actual Test  ///////
+		EventCallback 	callback;
+		char			buffer[64];
+
+		callback.setHandler(&PrintHelloWorld);
+		callback.handle();
+		////////////////////////////
+
+		int bytesRead = ::read(pipefd[0], buffer, 64);
+		buffer[bytesRead] = '\0';
+
+		// restore stdout
+		dup2(duplicate, STDOUT_FILENO);
+		close(pipefd[0]);
+		close(pipefd[1]);
+		close(duplicate);
+
+		if (std::string(buffer) != "Hello World!")
+			throw std::runtime_error("EventCallback failed to handle, got " 
+			+ std::string(buffer) + ", expected " 
+			+ std::string("Hello World!") + '\n'
+			+ TestHelpers::FileLineFunction(__FILE__, __LINE__, __FUNCTION__));
+		
+		std::cout << "	PASSED (passing a non-member function pointer and no user)" << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << "	FAILED: " << e.what()  << std::endl;
+	}
+
+	//valgrind, yes
+	close(STDOUT_FILENO);
+
+	std::cout << "*********************************************\n" << std::endl;
+}

--- a/Webserv/GenericUtils/Webserver_Definitions.h
+++ b/Webserv/GenericUtils/Webserver_Definitions.h
@@ -20,6 +20,7 @@
 # include <cerrno>
 # include <signal.h>
 # include <cassert>
+# include <string>
 
 
 // definitions for everyone to use
@@ -61,5 +62,26 @@ typedef union
 }   u_sockaddr;
 
 # define MAX_EPOLL_EVENTS 64
+
+namespace Ws
+{
+	typedef int			fd;
+	typedef pid_t		pid;
+
+	namespace Epoll
+	{
+		enum
+		{
+			NONE = 0,
+			READ = EPOLLIN,
+			WRITE = EPOLLOUT,
+			ERROR = EPOLLERR,
+			HANGUP = EPOLLHUP,
+			RHANGUP = EPOLLRDHUP,
+			EDGE_T = EPOLLET
+		};
+		typedef int Events;
+	}
+}
 
 #endif


### PR DESCRIPTION
- Adding EventCallback to the project.
- Minor cleanup of some old macros on Toolkit
- Adding namespace Ws on GenericUtils/Webserver_Definitions.h to have typedefs tied to a namespace
(nothing erased for compatibility, just added)

######################################
About EventCallback:
[to run tests: `cd "$(git rev-parse --show-toplevel)/Webserv/EventCallback/_Tests" && make test` ]

EventCallback is what wraps the handling of events.

EventCallbacks are to be subscribed to the EventManager to monitor.

When the EventManager detects an event on the file descriptor
to which EventCallback is assigned, it calls EventCallback::handle()
to execute the action (Callback) as a response to that event.

This "action" is essentially a function pointer that takes the EventCallback itself as an argument.
"Why?" to retain flexibility and allow us to use void* without pissing off the compiler.

EventCallback::Handler is [void (*Handler)(EventCallback& event)]

We need this intermediary step because the EventCallback knows nothing about its users:
	-> it can't typecast the m_user to the correct type.

So flexibility implies the user must actually follow something along these lines:

#################################
Example 1 (in the test cases):

```
class User
{
	public:
		void doSomething()
		{
			m_data = 42;
		}

		static void MyCallback_doSomething(EventCallback& event)
		{
			user* me = reinterpret_cast<user*>(event.accessUser());
			me->doSomething();
		}

		int getData() const
		{
			return (m_data);
		}
	private
		int	m_data;
}
```

when we setup the EventCallback, we will do:

```
User			user;
EventCallback 	callback;

callback.setUser(user);
callback.setHandler(&User::MyCallback_doSomething);

callback.handle();

assert(user.getData() == 42); //<- should be true
```

#####################################

So the function pointer cannot be a member function. We could do this with polymorphism but
no thanks.

The user supplies a static member function that internally typecasts the EventCallback::m_user
to its own type and calls its own method to be executed.

So like this, we decoupled the EventCallback from the actual users.

Notice though, THERE IS NO TYPESAFETY HERE.
The programmer must supply a user and a handler that match, otherwise be ready for chaos.


###################################


In handle, the EventCallback just checks that a handler exists and not a User.
The reason being, maybe the handler does not need any external data to do what it has to do.
Maybe it accesses globals, or maybe it just prints to std::cout.

so if you want to pass a handler say:

Example 2 (in the test cases):

```
void	SomeHandler(EventCallback& callback)
{
	(void)callback;

	std::cout << "Hello World!" << std::endl;
}

EventCallback callback;

callback.setHandler(&SomeHandler);

callback.handle();
```

##################################

Ok so the above is the callback part. Now we get to the event part.
This class serves to execute an action based on an event that happpened.
In our setup, the "events" are simply, input and output on file descriptors.
This class doesn't track anything, simple "reactsJS" to an event that happened.

Still whoever tracks the event must have a file descriptor to monitor and some
event types to monitor (read, write, hang-up).

We are using epoll as our event monitor so we pass the relevant file descriptor
and the epollflags we want to monitor (Ws::Epoll).

In a real context, the EventCallback::Handler would be something like HttpRead,
the EventCallback::User would be HttpConnection, the fd would be the Client socket,
and the flags would be Ws::Epoll::READ and Ws::Epoll::WRITE.

######################################

Member Functions:

```
//methods
void					handle();			//handles the subscribed event
void					reset();			//sets all internals back to "empty"

// accessors
EventCallback::User		accessUser();		//allow the caller to access the User and then typecast it
EventCallback::Handler	accessHandler();	//The function pointer that will be called

//getters
Ws::fd				getFd()					const;		
Ws::Epoll::Events		getMonitoredEvents()		const;		//the events we are asking to monitor (read, write)
Ws::Epoll::Events		getTriggeredEvents()		const;		//the events that resulted in the EventCallback being called
																	//(this value will be set by EventManager, letting us know "what happened")

		//setters
void					setFd				(const Ws::fd fd);
void					setMonitoredEvents	(const Ws::Epoll::Events flags);
void					setUser				(const EventCallback::User data);
void					setHandler			(const EventCallback::Handler handler);
void					setUserHandler		(const EventCallback::User data, const EventCallback::Handler handler);	
```


##############################################

Design considerations

No setters for triggered flags are provided:
the user is not supposed to set this value.

Internally, our EventsManager will set these flags when processing events, by having
an InternalEventCallback that inherits from this one and adds the relevant flags to it.

We do opt to still allocate space for these extra member variables in the base class itself
just not to have to copy events all the time, we use the same base instance and
inherit from it to modify the remaining parts.

So, a user could still messup the class but either the EventManager would have to be the sole supplier
of Events or we would have to do a lot of copying for very little gain.

In CgiModule, the Cgi::Module will be the sole supplier of Cgi::Request which allows a more clear separation
as we expose the public part of Request to the User while having access to extra internals.

##########################################


EDIT: some typos and formatting
EDIT2: tabs get really ugly, sorry about that